### PR TITLE
Added a "strings" loader for requiring files as raw strings

### DIFF
--- a/build/get-webpack-config.js
+++ b/build/get-webpack-config.js
@@ -35,6 +35,7 @@ const {
   syncChunkIdsLoader,
   syncChunkPathsLoader,
   swLoader,
+  stringLoader,
 } = require('./loaders/index.js');
 const {
   translationsManifestContextKey,
@@ -412,6 +413,7 @@ function getWebpackConfig(opts /*: WebpackConfigOpts */) {
         [chunkUrlMapLoader.alias]: chunkUrlMapLoader.path,
         [i18nManifestLoader.alias]: i18nManifestLoader.path,
         [swLoader.alias]: swLoader.path,
+        [stringLoader.alias]: stringLoader.path,
       },
     },
     plugins: [

--- a/build/loaders/index.js
+++ b/build/loaders/index.js
@@ -43,6 +43,10 @@ const loaderIndex = {
     alias: '__SECRET_SW_LOADER__',
     path: require.resolve('./sw-loader.js'),
   },
+  stringLoader: {
+    alias: '___SECRET_STRING_LOADER___',
+    path: require.resolve('./string-loader.js'),
+  }
 };
 
 module.exports = loaderIndex;

--- a/build/loaders/string-loader.js
+++ b/build/loaders/string-loader.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+/* eslint-env node */
+
+module.exports = function rawLoader(source) {
+  this.value = source;
+
+  const json = JSON.stringify(source)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+
+  return `module.exports = ${json}`;
+};


### PR DESCRIPTION
Useful for importing *.js files themselves as strings for docs/copyable snippets. Usage is similar to existing loaders, where the loader is "hidden" via `___SECRET_STRING_LOADER___`